### PR TITLE
Add multi-step wizard for creating events

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import { Analytics } from '@vercel/analytics/react';
 import NavBar from './NavBar';
 import OurStory from './Pages/OurStory'
 import Events from './Pages/EventsList';
+import AddEvent from './Pages/AddEvent';
 import { LoginPage } from './Pages/Login';
 import PrivateRoute from './PrivateRoute';
 import { useAuth } from './AuthContext';
@@ -28,6 +29,11 @@ function App() {
             <Route path="events" element={
               <PrivateRoute>
                 <Events />
+              </PrivateRoute>
+            } />
+            <Route path="events/new" element={
+              <PrivateRoute>
+                <AddEvent />
               </PrivateRoute>
             } />
             {/* <Route path="letter" element={<Letter />} /> */}

--- a/src/Components/ui/dialog.jsx
+++ b/src/Components/ui/dialog.jsx
@@ -4,7 +4,7 @@ import * as React from "react"
 import { Dialog as DialogPrimitive } from "@base-ui/react/dialog"
 
 import { cn } from "@/lib/utils"
-import { Button } from "@/components/ui/button"
+import { Button } from "@/Components/ui/button"
 import { XIcon } from "lucide-react"
 
 function Dialog({

--- a/src/Pages/AddEvent/StepDetails.jsx
+++ b/src/Pages/AddEvent/StepDetails.jsx
@@ -1,0 +1,221 @@
+import { useState } from 'react'
+import { Calendar as CalendarIcon, MapPin, Tag, Users } from 'lucide-react'
+import { Calendar } from '@/components/ui/calendar'
+import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover'
+import { LocationSearchBox } from '../EventsList/Components/LocationSearchBox'
+
+export function StepDetails({ formData, updateFormData, errors, defaultCategories }) {
+  const [newCategory, setNewCategory] = useState('')
+  const [showCategoryInput, setShowCategoryInput] = useState(false)
+  const [newPerson, setNewPerson] = useState('')
+  const [showPersonInput, setShowPersonInput] = useState(false)
+  const [calendarOpen, setCalendarOpen] = useState(false)
+
+  const allCategories = [...new Set([...defaultCategories, ...formData.categories])]
+
+  const toggleCategory = (cat) => {
+    const current = formData.categories
+    if (current.includes(cat)) {
+      updateFormData({ categories: current.filter(c => c !== cat) })
+    } else {
+      updateFormData({ categories: [...current, cat] })
+    }
+  }
+
+  const addCategory = () => {
+    const trimmed = newCategory.trim()
+    if (trimmed && !allCategories.includes(trimmed)) {
+      updateFormData({ categories: [...formData.categories, trimmed] })
+    } else if (trimmed && allCategories.includes(trimmed) && !formData.categories.includes(trimmed)) {
+      updateFormData({ categories: [...formData.categories, trimmed] })
+    }
+    setNewCategory('')
+    setShowCategoryInput(false)
+  }
+
+  const addPerson = () => {
+    const trimmed = newPerson.trim()
+    if (trimmed && !formData.people.includes(trimmed)) {
+      updateFormData({ people: [...formData.people, trimmed] })
+    }
+    setNewPerson('')
+    setShowPersonInput(false)
+  }
+
+  const removePerson = (person) => {
+    updateFormData({ people: formData.people.filter(p => p !== person) })
+  }
+
+  const handleLocationChange = (location) => {
+    const locationText = location?.label ?? ''
+    updateFormData({ location: locationText })
+  }
+
+  const formatDate = (date) => {
+    if (!date) return null
+    return date.toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    })
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Date */}
+      <div>
+        <label className="text-xs uppercase tracking-wider text-muted-text mb-2 block">
+          Date
+        </label>
+        <Popover open={calendarOpen} onOpenChange={setCalendarOpen}>
+          <PopoverTrigger
+            className={`w-full flex items-center gap-3 p-3.5 rounded-lg border transition-colors text-left ${
+              errors.date
+                ? 'border-destructive bg-destructive/5'
+                : 'border-accent-warm bg-surface hover:border-sienna/50'
+            }`}
+          >
+            <CalendarIcon size={18} className="text-sienna shrink-0" />
+            <span className={formData.date ? 'text-text text-sm' : 'text-muted-text text-sm'}>
+              {formatDate(formData.date) || 'Select a date'}
+            </span>
+          </PopoverTrigger>
+          <PopoverContent align="start" className="w-auto p-0">
+            <Calendar
+              mode="single"
+              selected={formData.date}
+              onSelect={(date) => {
+                updateFormData({ date })
+                setCalendarOpen(false)
+              }}
+            />
+          </PopoverContent>
+        </Popover>
+        {errors.date && <p className="text-destructive text-xs mt-1.5">{errors.date}</p>}
+      </div>
+
+      {/* Location */}
+      <div>
+        <label className="text-xs uppercase tracking-wider text-muted-text mb-2 block">
+          Place
+        </label>
+        <div className={`rounded-lg border transition-colors ${
+          errors.location
+            ? 'border-destructive bg-destructive/5'
+            : 'border-accent-warm bg-surface'
+        }`}>
+          <div className="flex items-center gap-3 px-3.5">
+            <MapPin size={18} className="text-sienna shrink-0" />
+            <div className="flex-1 [&_.css-b62m3t-container]:border-0 [&_*]:!border-0 [&_*]:!shadow-none [&_.css-13cymwt-control]:!bg-transparent [&_.css-t3ipsp-control]:!bg-transparent [&_.css-1dimb5e-singleValue]:!text-text [&_.css-1jqq78o-placeholder]:!text-muted-text">
+              <LocationSearchBox
+                onSelectLocation={handleLocationChange}
+                currentLocation={formData.location}
+                editMode={true}
+              />
+            </div>
+          </div>
+        </div>
+        {errors.location && <p className="text-destructive text-xs mt-1.5">{errors.location}</p>}
+      </div>
+
+      {/* Categories */}
+      <div>
+        <label className="text-xs uppercase tracking-wider text-muted-text mb-2 block">
+          <Tag size={12} className="inline mr-1.5 relative -top-px" />
+          Category (optional)
+        </label>
+        <div className="flex flex-wrap gap-2">
+          {allCategories.map((cat) => (
+            <button
+              key={cat}
+              onClick={() => toggleCategory(cat)}
+              className={`px-3 py-1.5 rounded-full text-xs font-medium transition-colors ${
+                formData.categories.includes(cat)
+                  ? 'bg-sienna text-white'
+                  : 'bg-accent-warm/50 text-muted-text hover:bg-accent-warm'
+              }`}
+            >
+              {cat}
+            </button>
+          ))}
+          {showCategoryInput ? (
+            <div className="flex items-center gap-1">
+              <input
+                autoFocus
+                value={newCategory}
+                onChange={(e) => setNewCategory(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') addCategory()
+                  if (e.key === 'Escape') setShowCategoryInput(false)
+                }}
+                onBlur={() => {
+                  if (newCategory.trim()) addCategory()
+                  else setShowCategoryInput(false)
+                }}
+                placeholder="Type..."
+                className="px-2 py-1 text-xs border border-accent-warm rounded-full w-20 bg-transparent outline-none focus:border-sienna"
+              />
+            </div>
+          ) : (
+            <button
+              onClick={() => setShowCategoryInput(true)}
+              className="px-3 py-1.5 rounded-full text-xs font-medium border border-dashed border-accent-warm text-muted-text hover:border-sienna hover:text-sienna transition-colors"
+            >
+              + add
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* People */}
+      <div>
+        <label className="text-xs uppercase tracking-wider text-muted-text mb-2 block">
+          <Users size={12} className="inline mr-1.5 relative -top-px" />
+          Who&apos;s in it
+        </label>
+        <div className="flex flex-wrap gap-2">
+          {formData.people.map((person) => (
+            <span
+              key={person}
+              className="px-3 py-1.5 rounded-full text-xs font-medium bg-sienna/10 text-sienna flex items-center gap-1.5"
+            >
+              {person}
+              <button
+                onClick={() => removePerson(person)}
+                className="hover:text-sienna-dark"
+              >
+                ×
+              </button>
+            </span>
+          ))}
+          {showPersonInput ? (
+            <div className="flex items-center gap-1">
+              <input
+                autoFocus
+                value={newPerson}
+                onChange={(e) => setNewPerson(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') addPerson()
+                  if (e.key === 'Escape') setShowPersonInput(false)
+                }}
+                onBlur={() => {
+                  if (newPerson.trim()) addPerson()
+                  else setShowPersonInput(false)
+                }}
+                placeholder="Name..."
+                className="px-2 py-1 text-xs border border-accent-warm rounded-full w-20 bg-transparent outline-none focus:border-sienna"
+              />
+            </div>
+          ) : (
+            <button
+              onClick={() => setShowPersonInput(true)}
+              className="px-3 py-1.5 rounded-full text-xs font-medium border border-dashed border-accent-warm text-muted-text hover:border-sienna hover:text-sienna transition-colors"
+            >
+              + add person
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/Pages/AddEvent/StepDetails.jsx
+++ b/src/Pages/AddEvent/StepDetails.jsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { Calendar as CalendarIcon, MapPin, Tag, Users } from 'lucide-react'
-import { Calendar } from '@/components/ui/calendar'
-import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover'
+import { Calendar } from '@/Components/ui/calendar'
+import { Popover, PopoverTrigger, PopoverContent } from '@/Components/ui/popover'
 import { LocationSearchBox } from '../EventsList/Components/LocationSearchBox'
 
 export function StepDetails({ formData, updateFormData, errors, defaultCategories }) {

--- a/src/Pages/AddEvent/StepPhotos.jsx
+++ b/src/Pages/AddEvent/StepPhotos.jsx
@@ -1,0 +1,80 @@
+import { useCallback } from 'react'
+import { useDropzone } from 'react-dropzone'
+import { ImagePlus, X } from 'lucide-react'
+
+export function StepPhotos({ files, onChange, error }) {
+  const onDrop = useCallback((acceptedFiles) => {
+    const newFiles = acceptedFiles.map(file =>
+      Object.assign(file, { preview: URL.createObjectURL(file) })
+    )
+    onChange([...files, ...newFiles])
+  }, [files, onChange])
+
+  const removeFile = (index) => {
+    const updated = files.filter((_, i) => i !== index)
+    onChange(updated)
+  }
+
+  const { getRootProps, getInputProps, isDragActive } = useDropzone({
+    accept: { 'image/*': [] },
+    onDrop,
+    multiple: true,
+  })
+
+  return (
+    <div>
+      {/* Photo grid */}
+      {files.length > 0 && (
+        <div className="grid grid-cols-3 gap-2 mb-4">
+          {files.map((file, idx) => (
+            <div key={idx} className="relative aspect-square rounded overflow-hidden border border-accent-warm">
+              <img
+                src={file.preview}
+                alt={`Selected ${idx + 1}`}
+                className="w-full h-full object-cover"
+              />
+              <button
+                onClick={() => removeFile(idx)}
+                className="absolute top-1 right-1 bg-text/70 text-white rounded-full p-0.5 hover:bg-text/90 transition-colors"
+              >
+                <X size={12} />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Dropzone */}
+      <div
+        {...getRootProps()}
+        className={`border-2 border-dashed rounded-lg p-8 text-center cursor-pointer transition-colors ${
+          isDragActive
+            ? 'border-sienna bg-sienna/5'
+            : error
+            ? 'border-destructive bg-destructive/5'
+            : 'border-accent-warm hover:border-sienna/50'
+        }`}
+      >
+        <input {...getInputProps()} />
+        <ImagePlus size={32} className="mx-auto mb-3 text-muted-text" />
+        <p className="text-sm text-muted-text">
+          {isDragActive
+            ? 'Drop photos here...'
+            : files.length > 0
+            ? 'Add more photos'
+            : 'Tap to select photos or drag & drop'}
+        </p>
+      </div>
+
+      {error && (
+        <p className="text-destructive text-xs mt-2">{error}</p>
+      )}
+
+      {files.length > 0 && (
+        <p className="text-xs text-muted-text mt-3">
+          {files.length} photo{files.length !== 1 ? 's' : ''} selected
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/Pages/AddEvent/StepStory.jsx
+++ b/src/Pages/AddEvent/StepStory.jsx
@@ -1,0 +1,127 @@
+import { useState } from 'react'
+import { Type, AlignLeft, Tags } from 'lucide-react'
+
+export function StepStory({ formData, updateFormData, errors }) {
+  const [newTag, setNewTag] = useState('')
+  const [showTagInput, setShowTagInput] = useState(false)
+
+  const addTag = () => {
+    const trimmed = newTag.trim().toLowerCase()
+    if (trimmed && !formData.tags.includes(trimmed)) {
+      updateFormData({ tags: [...formData.tags, trimmed] })
+    }
+    setNewTag('')
+    setShowTagInput(false)
+  }
+
+  const removeTag = (tag) => {
+    updateFormData({ tags: formData.tags.filter(t => t !== tag) })
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Title */}
+      <div>
+        <label className="text-xs uppercase tracking-wider text-muted-text mb-2 block">
+          <Type size={12} className="inline mr-1.5 relative -top-px" />
+          Title
+        </label>
+        <input
+          value={formData.title}
+          onChange={(e) => updateFormData({ title: e.target.value })}
+          placeholder="Give this event a name..."
+          className={`w-full p-3.5 rounded-lg border bg-surface text-sm outline-none transition-colors ${
+            errors.title
+              ? 'border-destructive'
+              : 'border-accent-warm focus:border-sienna'
+          }`}
+        />
+        {errors.title && <p className="text-destructive text-xs mt-1.5">{errors.title}</p>}
+      </div>
+
+      {/* Description */}
+      <div>
+        <label className="text-xs uppercase tracking-wider text-muted-text mb-2 block">
+          <AlignLeft size={12} className="inline mr-1.5 relative -top-px" />
+          Description (optional)
+        </label>
+        <textarea
+          value={formData.description}
+          onChange={(e) => updateFormData({ description: e.target.value })}
+          placeholder="Write about this memory..."
+          rows={4}
+          className="w-full p-3.5 rounded-lg border border-accent-warm bg-surface text-sm outline-none transition-colors focus:border-sienna resize-none"
+        />
+      </div>
+
+      {/* Tags */}
+      <div>
+        <label className="text-xs uppercase tracking-wider text-muted-text mb-2 block">
+          <Tags size={12} className="inline mr-1.5 relative -top-px" />
+          Tags (optional)
+        </label>
+        <div className="flex flex-wrap gap-2">
+          {formData.tags.map((tag) => (
+            <span
+              key={tag}
+              className="px-3 py-1.5 rounded-full text-xs font-medium bg-accent-warm/50 text-text flex items-center gap-1.5"
+            >
+              {tag}
+              <button
+                onClick={() => removeTag(tag)}
+                className="text-muted-text hover:text-text"
+              >
+                ×
+              </button>
+            </span>
+          ))}
+          {showTagInput ? (
+            <div className="flex items-center gap-1">
+              <input
+                autoFocus
+                value={newTag}
+                onChange={(e) => setNewTag(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') addTag()
+                  if (e.key === 'Escape') setShowTagInput(false)
+                }}
+                onBlur={() => {
+                  if (newTag.trim()) addTag()
+                  else setShowTagInput(false)
+                }}
+                placeholder="Tag..."
+                className="px-2 py-1 text-xs border border-accent-warm rounded-full w-20 bg-transparent outline-none focus:border-sienna"
+              />
+            </div>
+          ) : (
+            <button
+              onClick={() => setShowTagInput(true)}
+              className="px-3 py-1.5 rounded-full text-xs font-medium border border-dashed border-accent-warm text-muted-text hover:border-sienna hover:text-sienna transition-colors"
+            >
+              + add
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Preview of photos */}
+      {formData.files.length > 0 && (
+        <div>
+          <label className="text-xs uppercase tracking-wider text-muted-text mb-2 block">
+            Photos
+          </label>
+          <div className="flex gap-2 overflow-x-auto pb-2">
+            {formData.files.map((file, idx) => (
+              <img
+                key={idx}
+                src={file.preview}
+                alt={`Photo ${idx + 1}`}
+                className="w-16 h-16 object-cover rounded border border-accent-warm shrink-0"
+              />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/Pages/AddEvent/index.jsx
+++ b/src/Pages/AddEvent/index.jsx
@@ -1,0 +1,199 @@
+import { useState, useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { Timestamp } from 'firebase/firestore'
+import { uploadEvent } from '../../db'
+import { StepPhotos } from './StepPhotos'
+import { StepDetails } from './StepDetails'
+import { StepStory } from './StepStory'
+import { ArrowLeft } from 'lucide-react'
+import { useToast } from '@chakra-ui/react'
+
+const STEPS = ['Pick Photos', 'When & Where', 'Tell the Story']
+
+const DEFAULT_CATEGORIES = ['Meals', 'Gifts', 'Trips']
+
+export default function AddEvent() {
+  const navigate = useNavigate()
+  const toast = useToast()
+  const [currentStep, setCurrentStep] = useState(0)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const [formData, setFormData] = useState({
+    files: [],
+    date: null,
+    location: '',
+    categories: [],
+    people: [],
+    title: '',
+    description: '',
+    tags: [],
+  })
+
+  const [errors, setErrors] = useState({})
+
+  const updateFormData = useCallback((updates) => {
+    setFormData(prev => ({ ...prev, ...updates }))
+    setErrors(prev => {
+      const next = { ...prev }
+      Object.keys(updates).forEach(key => delete next[key])
+      return next
+    })
+  }, [])
+
+  const validateStep = (step) => {
+    const newErrors = {}
+
+    if (step === 0) {
+      if (!formData.files.length) {
+        newErrors.files = 'Please select at least one photo'
+      }
+    } else if (step === 1) {
+      if (!formData.date) {
+        newErrors.date = 'Date is required'
+      }
+      if (!formData.location) {
+        newErrors.location = 'Location is required'
+      }
+    } else if (step === 2) {
+      if (!formData.title.trim()) {
+        newErrors.title = 'Title is required'
+      }
+    }
+
+    setErrors(newErrors)
+    return Object.keys(newErrors).length === 0
+  }
+
+  const handleNext = () => {
+    if (validateStep(currentStep)) {
+      setCurrentStep(prev => Math.min(prev + 1, STEPS.length - 1))
+    }
+  }
+
+  const handleBack = () => {
+    setCurrentStep(prev => Math.max(prev - 1, 0))
+  }
+
+  const handleSubmit = async () => {
+    if (!validateStep(currentStep)) return
+
+    setIsSubmitting(true)
+    try {
+      const eventPayload = {
+        title: formData.title.trim(),
+        description: formData.description.trim(),
+        date: Timestamp.fromDate(formData.date),
+        location: formData.location,
+        categories: formData.categories,
+        people: formData.people,
+        tags: formData.tags,
+        files: formData.files,
+      }
+
+      await uploadEvent(eventPayload)
+
+      toast({
+        title: 'Event saved!',
+        description: 'Your event has been added successfully.',
+        status: 'success',
+        duration: 3000,
+        isClosable: true,
+      })
+
+      navigate('/events')
+    } catch (error) {
+      console.error('Failed to save event:', error)
+      toast({
+        title: 'Error',
+        description: 'Failed to save event. Please try again.',
+        status: 'error',
+        duration: 4000,
+        isClosable: true,
+      })
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="min-h-[calc(100vh-80px)] bg-parchment flex flex-col">
+      <div className="max-w-lg mx-auto px-5 py-6 flex-1 w-full pb-24">
+        {/* Header */}
+        <div className="flex items-center justify-between mb-6">
+          <button
+            onClick={() => currentStep === 0 ? navigate('/events') : handleBack()}
+            className="flex items-center gap-1.5 text-muted-text hover:text-text transition-colors text-sm"
+          >
+            <ArrowLeft size={16} />
+            {currentStep === 0 ? 'Cancel' : 'Back'}
+          </button>
+          <h1 className="font-display text-xl font-medium text-text">New Event</h1>
+          <div className="w-14" />
+        </div>
+
+        {/* Progress bar */}
+        <div className="mb-8">
+          <div className="flex items-center gap-1 mb-2">
+            {STEPS.map((_, idx) => (
+              <div
+                key={idx}
+                className={`h-1 flex-1 rounded-full transition-colors ${
+                  idx <= currentStep ? 'bg-sienna' : 'bg-accent-warm'
+                }`}
+              />
+            ))}
+          </div>
+          <p className="text-xs uppercase tracking-wider text-muted-text">
+            Step {currentStep + 1} of {STEPS.length} — {STEPS[currentStep]}
+          </p>
+        </div>
+
+        {/* Step content */}
+        {currentStep === 0 && (
+          <StepPhotos
+            files={formData.files}
+            onChange={(files) => updateFormData({ files })}
+            error={errors.files}
+          />
+        )}
+        {currentStep === 1 && (
+          <StepDetails
+            formData={formData}
+            updateFormData={updateFormData}
+            errors={errors}
+            defaultCategories={DEFAULT_CATEGORIES}
+          />
+        )}
+        {currentStep === 2 && (
+          <StepStory
+            formData={formData}
+            updateFormData={updateFormData}
+            errors={errors}
+          />
+        )}
+      </div>
+
+      {/* Fixed bottom button */}
+      <div className="fixed bottom-0 left-0 right-0 bg-parchment border-t border-accent-warm/30 px-5 py-4">
+        <div className="max-w-lg mx-auto">
+          {currentStep < STEPS.length - 1 ? (
+            <button
+              onClick={handleNext}
+              className="w-full bg-foreground text-background py-3.5 rounded font-medium text-sm uppercase tracking-wider hover:opacity-90 transition-opacity"
+            >
+              Next
+            </button>
+          ) : (
+            <button
+              onClick={handleSubmit}
+              disabled={isSubmitting}
+              className="w-full bg-foreground text-background py-3.5 rounded font-medium text-sm uppercase tracking-wider hover:opacity-90 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {isSubmitting ? 'Saving...' : 'Save Event'}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/Pages/EventsList/Components/SearchFilter.jsx
+++ b/src/Pages/EventsList/Components/SearchFilter.jsx
@@ -8,9 +8,11 @@ import {
 } from '@chakra-ui/react'
 import { AddIcon } from '@chakra-ui/icons'
 import { SlidersHorizontal, Search } from 'lucide-react'
+import { useNavigate } from 'react-router-dom'
 
 
 export const SearchFilter = ({ onAddModalOpen, onSearchEvent, hasActiveFilters, onToggleFilterPanel, isFilterOpen }) => {
+    const navigate = useNavigate()
     return (
         <Box display="flex" gap="10px" pt="20px" px="20px" alignItems="center">
             <InputGroup flex="1">
@@ -76,7 +78,7 @@ export const SearchFilter = ({ onAddModalOpen, onSearchEvent, hasActiveFilters, 
             </Box>
 
             <Button
-                onClick={onAddModalOpen}
+                onClick={() => navigate('/events/new')}
                 bg="#B48261"
                 color="white"
                 height="40px"

--- a/src/db/index.js
+++ b/src/db/index.js
@@ -13,17 +13,27 @@ export const getEvents = async () => {
 
 export const uploadEvent = async (newEvent) => {
     const eventsCol = collection(db, "events");
-    const { file, ...eventData } = newEvent
+    const { file, files, ...eventData } = newEvent
 
     const completeEventData = { ...eventData }
     const storage = getStorage();
 
     try {
-        if (file) {
+        if (files && files.length > 0) {
+            const photoURLs = await Promise.all(
+                files.map(async (f) => {
+                    const storageRef = ref(storage, `events/${Date.now()}_${f.name}`);
+                    const fileSnapshot = await uploadBytes(storageRef, f);
+                    return getDownloadURL(fileSnapshot.ref);
+                })
+            );
+            completeEventData["photos"] = photoURLs;
+            completeEventData["thumbnail"] = photoURLs[0];
+        } else if (file) {
             const storageRef = ref(storage, `events/${file.name}`);
             const fileSnapshot = await uploadBytes(storageRef, file);
             const photoURL = await getDownloadURL(fileSnapshot.ref);
-            completeEventData["thumbnail"] = photoURL
+            completeEventData["thumbnail"] = photoURL;
         }
 
         const docRef = await addDoc(eventsCol, completeEventData);

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,4 @@
-@import "tailwindcss";
+@import "tailwindcss" important;
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
 @import "@fontsource/newsreader/400.css";
@@ -166,3 +166,4 @@ code {
     @apply font-sans antialiased;
   }
 }
+

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,5 +1,6 @@
 export const routesWithinApp = [
     '/',
     '/events',
+    '/events/new',
     '/letter',
 ]


### PR DESCRIPTION
## Summary
- Replaces the modal-based "Add Event" dialog with a full-page 3-step wizard at `/events/new`
- Step 1: Multi-photo upload with drag & drop grid
- Step 2: Date picker (shadcn Calendar), Google Places location search, multi-select categories with custom add, people tagging
- Step 3: Title, description, free-form tags
- Fixed bottom "Next"/"Save Event" button pinned to screen bottom
- Updated `uploadEvent` to support multiple photo uploads (stores array in `photos` field + first as `thumbnail` for backwards compat)
- Added `@import "tailwindcss" important` to resolve Chakra/Tailwind CSS specificity conflicts

## Test plan
- [ ] Navigate to `/events` and click "Add" button → should go to `/events/new`
- [ ] Step 1: Upload photos via drag & drop or click, verify grid display and remove button
- [ ] Step 1: Click Next without photos → validation error shown
- [ ] Step 2: Select date from calendar popover
- [ ] Step 2: Search and select location via Google Places
- [ ] Step 2: Toggle category chips, add custom categories
- [ ] Step 2: Add people names
- [ ] Step 3: Fill title and description, add tags
- [ ] Submit → event saved to Firestore with photos uploaded to Storage, redirects to `/events`
- [ ] Cancel/Back navigation works correctly
- [ ] Existing events page and Our Story page have no visual regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)