### PR TITLE
Add event detail page and 4-step edit wizard

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,8 @@ import NavBar from './NavBar';
 import OurStory from './Pages/OurStory'
 import Events from './Pages/EventsList';
 import AddEvent from './Pages/AddEvent';
+import EventDetail from './Pages/EventDetail';
+import EditEvent from './Pages/EditEvent';
 import { LoginPage } from './Pages/Login';
 import PrivateRoute from './PrivateRoute';
 import { useAuth } from './AuthContext';
@@ -34,6 +36,16 @@ function App() {
             <Route path="events/new" element={
               <PrivateRoute>
                 <AddEvent />
+              </PrivateRoute>
+            } />
+            <Route path="events/:id" element={
+              <PrivateRoute>
+                <EventDetail />
+              </PrivateRoute>
+            } />
+            <Route path="events/:id/edit" element={
+              <PrivateRoute>
+                <EditEvent />
               </PrivateRoute>
             } />
             {/* <Route path="letter" element={<Letter />} /> */}

--- a/src/Pages/EditEvent/Saved.jsx
+++ b/src/Pages/EditEvent/Saved.jsx
@@ -1,0 +1,94 @@
+import { useNavigate } from 'react-router-dom'
+import { Check, ArrowLeft } from 'lucide-react'
+import { toJsDate } from '../../utils'
+
+function formatLongDate(date) {
+  const d = toJsDate(date)
+  if (!d) return ''
+  const weekday = d.toLocaleDateString('en-US', { weekday: 'short' }).toUpperCase()
+  const month = d.toLocaleDateString('en-US', { month: 'short' }).toUpperCase()
+  return `${weekday} · ${month} ${d.getDate()} · ${d.getFullYear()}`
+}
+
+export function Saved({ event, onEditAgain }) {
+  const navigate = useNavigate()
+  const categories = event.categories?.length ? event.categories : []
+  const people = event.people || []
+  const partner = people.find((p) => p.toLowerCase() !== 'you')
+
+  const goToEventsList = () => navigate('/events')
+
+  return (
+    <div className="min-h-[calc(100vh-80px)] bg-parchment flex flex-col">
+      <div className="flex items-center justify-between px-5 pt-4 pb-2">
+        <button
+          onClick={goToEventsList}
+          aria-label="Back to events"
+          className="w-9 h-9 rounded-full bg-surface shadow-soft flex items-center justify-center text-text hover:bg-accent-warm/40 transition-colors"
+        >
+          <ArrowLeft size={18} />
+        </button>
+        <span className="text-[12px] font-medium tracking-[0.2em] text-muted-text uppercase">Saved</span>
+        <span className="w-9 h-9" aria-hidden />
+      </div>
+
+      <div className="flex-1 px-5 pb-28 pt-8 max-w-lg w-full mx-auto">
+        <div className="flex flex-col items-center text-center mb-8">
+          <div className="w-16 h-16 rounded-full bg-sienna flex items-center justify-center mb-5">
+            <Check size={28} className="text-white" strokeWidth={2.5} />
+          </div>
+          <h1 className="font-display text-[28px] leading-[1.1] text-text">
+            Changes <em className="italic">saved.</em>
+          </h1>
+          {partner && (
+            <p className="text-muted-text text-sm mt-3 max-w-xs">
+              {partner} will see the updated event on their side too.
+            </p>
+          )}
+        </div>
+
+        <div className="bg-surface rounded-lg shadow-soft p-5">
+          {categories.length > 0 && (
+            <div className="flex flex-wrap gap-1.5 mb-3">
+              {categories.map((cat) => (
+                <span
+                  key={cat}
+                  className="inline-flex px-2 py-0.5 bg-accent-warm/60 text-text text-[10px] font-medium tracking-wider uppercase rounded-sm"
+                >
+                  {cat}
+                </span>
+              ))}
+            </div>
+          )}
+          <h2 className="font-display text-[22px] text-text leading-tight mb-2">{event.title}</h2>
+          <p className="text-[11px] uppercase tracking-[0.15em] text-muted-text">
+            {formatLongDate(event.date)}
+          </p>
+          {event.location && (
+            <p className="text-text/80 text-sm mt-2">{event.location}</p>
+          )}
+          {event.description && (
+            <p className="text-text/70 text-sm italic mt-3 leading-relaxed">{event.description}</p>
+          )}
+        </div>
+      </div>
+
+      <div className="fixed bottom-0 left-0 right-0 bg-parchment border-t border-accent-warm/30 px-5 py-4">
+        <div className="max-w-lg mx-auto flex items-center gap-3">
+          <button
+            onClick={onEditAgain}
+            className="px-5 py-3 rounded border border-accent-warm text-text text-xs uppercase tracking-[0.15em] hover:bg-accent-warm/30 transition-colors"
+          >
+            Edit again
+          </button>
+          <button
+            onClick={goToEventsList}
+            className="flex-1 py-3.5 rounded bg-foreground text-background font-medium text-xs uppercase tracking-[0.15em] hover:opacity-90 transition-opacity"
+          >
+            Back to events
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/Pages/EditEvent/StepBasics.jsx
+++ b/src/Pages/EditEvent/StepBasics.jsx
@@ -1,0 +1,94 @@
+import { useState } from 'react'
+import { Tag } from 'lucide-react'
+
+export function StepBasics({ formData, updateFormData, errors, defaultCategories }) {
+  const [newCategory, setNewCategory] = useState('')
+  const [showCategoryInput, setShowCategoryInput] = useState(false)
+
+  const allCategories = [...new Set([...defaultCategories, ...formData.categories])]
+
+  const toggleCategory = (cat) => {
+    const current = formData.categories
+    if (current.includes(cat)) {
+      updateFormData({ categories: current.filter((c) => c !== cat) })
+    } else {
+      updateFormData({ categories: [...current, cat] })
+    }
+  }
+
+  const addCategory = () => {
+    const trimmed = newCategory.trim()
+    if (trimmed && !formData.categories.includes(trimmed)) {
+      updateFormData({ categories: [...formData.categories, trimmed] })
+    }
+    setNewCategory('')
+    setShowCategoryInput(false)
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <label className="text-[11px] uppercase tracking-[0.15em] text-muted-text mb-2 block">
+          Title
+        </label>
+        <input
+          value={formData.title}
+          onChange={(e) => updateFormData({ title: e.target.value })}
+          placeholder="Give this event a name…"
+          className={`w-full p-3.5 rounded-lg border bg-surface text-text outline-none transition-colors ${
+            errors.title
+              ? 'border-destructive'
+              : 'border-accent-warm focus:border-sienna'
+          }`}
+        />
+        {errors.title && <p className="text-destructive text-xs mt-1.5">{errors.title}</p>}
+      </div>
+
+      <div>
+        <label className="text-[11px] uppercase tracking-[0.15em] text-muted-text mb-2 block">
+          <Tag size={11} className="inline mr-1.5 relative -top-px" />
+          Category
+        </label>
+        <div className="flex flex-wrap gap-2">
+          {allCategories.map((cat) => {
+            const active = formData.categories.includes(cat)
+            return (
+              <button
+                key={cat}
+                onClick={() => toggleCategory(cat)}
+                className={`px-3.5 py-2 rounded-md text-xs font-medium transition-colors ${
+                  active
+                    ? 'bg-foreground text-background'
+                    : 'bg-surface border border-accent-warm text-text hover:border-sienna'
+                }`}
+              >
+                {cat}
+              </button>
+            )
+          })}
+          {showCategoryInput ? (
+            <input
+              autoFocus
+              value={newCategory}
+              onChange={(e) => setNewCategory(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') addCategory()
+                if (e.key === 'Escape') setShowCategoryInput(false)
+              }}
+              onBlur={() => (newCategory.trim() ? addCategory() : setShowCategoryInput(false))}
+              placeholder="Type…"
+              className="px-3 py-2 text-xs border border-sienna rounded-md w-24 bg-surface outline-none"
+            />
+          ) : (
+            <button
+              onClick={() => setShowCategoryInput(true)}
+              className="px-3.5 py-2 rounded-md text-xs font-medium border border-dashed border-accent-warm text-muted-text hover:border-sienna hover:text-sienna transition-colors"
+            >
+              + Add
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/Pages/EditEvent/StepDetails.jsx
+++ b/src/Pages/EditEvent/StepDetails.jsx
@@ -1,0 +1,120 @@
+import { useState } from 'react'
+import { AlignLeft, Users, Plus, X } from 'lucide-react'
+
+export function StepDetails({ formData, updateFormData, errors }) {
+  const [newPerson, setNewPerson] = useState('')
+  const [showPersonInput, setShowPersonInput] = useState(false)
+
+  const addPerson = () => {
+    const trimmed = newPerson.trim()
+    if (trimmed && !formData.people.includes(trimmed)) {
+      updateFormData({ people: [...formData.people, trimmed] })
+    }
+    setNewPerson('')
+    setShowPersonInput(false)
+  }
+
+  const removePerson = (person) => {
+    updateFormData({ people: formData.people.filter((p) => p !== person) })
+  }
+
+  const removePhoto = (idx) => {
+    updateFormData({ photos: formData.photos.filter((_, i) => i !== idx) })
+  }
+
+  return (
+    <div className="space-y-7">
+      <div>
+        <label className="text-[11px] uppercase tracking-[0.15em] text-muted-text mb-2 block">
+          <AlignLeft size={11} className="inline mr-1.5 relative -top-px" />
+          Notes
+        </label>
+        <textarea
+          value={formData.description}
+          onChange={(e) => updateFormData({ description: e.target.value })}
+          placeholder="A little more to remember it by…"
+          rows={5}
+          className="w-full p-3.5 rounded-lg border border-accent-warm bg-surface text-text outline-none transition-colors focus:border-sienna resize-none"
+        />
+      </div>
+
+      <div>
+        <p className="text-[11px] uppercase tracking-[0.15em] text-muted-text mb-2">
+          Inspiration · Photos
+        </p>
+        <div className="grid grid-cols-4 gap-2">
+          {formData.photos.map((src, idx) => (
+            <div key={idx} className="relative aspect-square rounded-md overflow-hidden border border-accent-warm">
+              <img src={src} alt={`Photo ${idx + 1}`} className="w-full h-full object-cover" />
+              <button
+                onClick={() => removePhoto(idx)}
+                aria-label={`Remove photo ${idx + 1}`}
+                className="absolute top-1 right-1 w-5 h-5 rounded-full bg-black/60 text-white flex items-center justify-center hover:bg-black/80 transition-colors"
+              >
+                <X size={11} />
+              </button>
+            </div>
+          ))}
+          <button
+            disabled
+            title="Photo upload coming soon"
+            className="aspect-square rounded-md border border-dashed border-accent-warm flex items-center justify-center text-muted-text/60 cursor-not-allowed"
+          >
+            <Plus size={20} />
+          </button>
+        </div>
+      </div>
+
+      <div>
+        <label className="text-[11px] uppercase tracking-[0.15em] text-muted-text mb-2 block">
+          <Users size={11} className="inline mr-1.5 relative -top-px" />
+          Who's coming
+        </label>
+        <div className="flex flex-wrap gap-2">
+          {formData.people.map((person) => (
+            <div
+              key={person}
+              className="flex items-center gap-2 pl-1 pr-3 py-1 rounded-full bg-foreground text-background"
+            >
+              <span className="w-7 h-7 rounded-full bg-sienna text-white text-xs font-medium flex items-center justify-center">
+                {person.charAt(0).toUpperCase()}
+              </span>
+              <div className="flex flex-col leading-none">
+                <span className="text-[12px] font-medium">{person}</span>
+                <span className="text-[9px] uppercase tracking-[0.1em] opacity-70 mt-0.5">Going ✓</span>
+              </div>
+              <button
+                onClick={() => removePerson(person)}
+                aria-label={`Remove ${person}`}
+                className="ml-1 opacity-60 hover:opacity-100"
+              >
+                <X size={12} />
+              </button>
+            </div>
+          ))}
+          {showPersonInput ? (
+            <input
+              autoFocus
+              value={newPerson}
+              onChange={(e) => setNewPerson(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') addPerson()
+                if (e.key === 'Escape') setShowPersonInput(false)
+              }}
+              onBlur={() => (newPerson.trim() ? addPerson() : setShowPersonInput(false))}
+              placeholder="Name…"
+              className="px-3 py-2 text-xs border border-sienna rounded-full w-28 bg-surface outline-none"
+            />
+          ) : (
+            <button
+              onClick={() => setShowPersonInput(true)}
+              className="px-3 py-2 rounded-full text-xs font-medium border border-dashed border-accent-warm text-muted-text hover:border-sienna hover:text-sienna transition-colors"
+            >
+              + Add person
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/Pages/EditEvent/StepReview.jsx
+++ b/src/Pages/EditEvent/StepReview.jsx
@@ -1,0 +1,121 @@
+import { useState } from 'react'
+import { Tag, Calendar as CalendarIcon, MapPin, Users, AlignLeft, Trash2 } from 'lucide-react'
+
+function formatDate(date) {
+  if (!date) return '—'
+  return date.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric', year: 'numeric' })
+}
+
+export function StepReview({ formData, onEditStep, onDelete, isSubmitting }) {
+  const [confirmOpen, setConfirmOpen] = useState(false)
+
+  const rows = [
+    {
+      step: 0,
+      icon: <Tag size={14} className="text-sienna" />,
+      label: 'Title · Category',
+      value: (
+        <div>
+          <p className="text-text">{formData.title || '—'}</p>
+          {formData.categories.length > 0 && (
+            <p className="text-muted-text text-xs mt-1">{formData.categories.join(' · ')}</p>
+          )}
+        </div>
+      ),
+    },
+    {
+      step: 1,
+      icon: <CalendarIcon size={14} className="text-sienna" />,
+      label: 'When',
+      value: <p className="text-text">{formatDate(formData.date)}</p>,
+    },
+    {
+      step: 1,
+      icon: <MapPin size={14} className="text-sienna" />,
+      label: 'Where',
+      value: <p className="text-text truncate">{formData.location || '—'}</p>,
+    },
+    {
+      step: 2,
+      icon: <Users size={14} className="text-sienna" />,
+      label: 'Who',
+      value: <p className="text-text">{formData.people.join(' & ') || '—'}</p>,
+    },
+    {
+      step: 2,
+      icon: <AlignLeft size={14} className="text-sienna" />,
+      label: 'Notes',
+      value: (
+        <p className="text-text/80 line-clamp-3 text-sm leading-relaxed">
+          {formData.description || '—'}
+        </p>
+      ),
+    },
+  ]
+
+  return (
+    <div className="space-y-6">
+      <p className="text-text/70 text-sm leading-relaxed -mt-2">
+        A small recap. Tap any field to jump back and tweak.
+      </p>
+
+      <div className="bg-surface rounded-lg shadow-soft divide-y divide-accent-warm/40">
+        {rows.map((row, i) => (
+          <button
+            key={i}
+            onClick={() => onEditStep(row.step)}
+            className="w-full flex items-start gap-3 p-4 text-left hover:bg-accent-warm/20 transition-colors group"
+          >
+            <div className="w-8 h-8 rounded-full bg-accent-warm/40 flex items-center justify-center shrink-0">
+              {row.icon}
+            </div>
+            <div className="flex-1 min-w-0">
+              <p className="text-[10px] uppercase tracking-[0.15em] text-muted-text mb-1">{row.label}</p>
+              {row.value}
+            </div>
+            <span className="text-[11px] uppercase tracking-[0.15em] text-sienna shrink-0 self-center group-hover:underline">
+              Edit
+            </span>
+          </button>
+        ))}
+      </div>
+
+      <div className="pt-6 border-t border-accent-warm/40">
+        <p className="text-[10px] uppercase tracking-[0.15em] text-destructive/80 mb-3">
+          Danger zone
+        </p>
+        {!confirmOpen ? (
+          <button
+            onClick={() => setConfirmOpen(true)}
+            className="w-full flex items-center justify-center gap-2 py-3 rounded border border-dashed border-destructive/40 text-destructive text-xs uppercase tracking-[0.15em] hover:bg-destructive/5 transition-colors"
+          >
+            <Trash2 size={14} />
+            Delete event
+          </button>
+        ) : (
+          <div className="bg-destructive/5 border border-destructive/30 rounded-lg p-4">
+            <p className="text-sm text-text mb-3">
+              Delete this event permanently? This cannot be undone.
+            </p>
+            <div className="flex gap-2">
+              <button
+                onClick={() => setConfirmOpen(false)}
+                disabled={isSubmitting}
+                className="flex-1 py-2.5 rounded border border-accent-warm text-text text-xs uppercase tracking-[0.15em] hover:bg-accent-warm/30 transition-colors disabled:opacity-50"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={onDelete}
+                disabled={isSubmitting}
+                className="flex-1 py-2.5 rounded bg-destructive text-white text-xs uppercase tracking-[0.15em] hover:opacity-90 transition-opacity disabled:opacity-50"
+              >
+                {isSubmitting ? 'Deleting…' : 'Delete'}
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/Pages/EditEvent/StepWhenWhere.jsx
+++ b/src/Pages/EditEvent/StepWhenWhere.jsx
@@ -1,0 +1,115 @@
+import { useState } from 'react'
+import { Calendar as CalendarIcon, MapPin, Clock } from 'lucide-react'
+import { Calendar } from '@/Components/ui/calendar'
+import { Popover, PopoverTrigger, PopoverContent } from '@/Components/ui/popover'
+import { LocationSearchBox } from '../EventsList/Components/LocationSearchBox'
+
+function formatDate(date) {
+  if (!date) return null
+  return date.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' })
+}
+
+export function StepWhenWhere({ formData, updateFormData, errors, recentPlaces }) {
+  const [calendarOpen, setCalendarOpen] = useState(false)
+  const [showLocationSearch, setShowLocationSearch] = useState(false)
+
+  const handleLocationChange = (location) => {
+    const text = location?.label ?? ''
+    updateFormData({ location: text })
+    setShowLocationSearch(false)
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <label className="text-[11px] uppercase tracking-[0.15em] text-muted-text mb-2 block">
+          <CalendarIcon size={11} className="inline mr-1.5 relative -top-px" />
+          Date
+        </label>
+        <Popover open={calendarOpen} onOpenChange={setCalendarOpen}>
+          <PopoverTrigger
+            className={`w-full flex items-center gap-3 p-3.5 rounded-lg border bg-surface text-left transition-colors ${
+              errors.date ? 'border-destructive' : 'border-accent-warm hover:border-sienna/50'
+            }`}
+          >
+            <CalendarIcon size={16} className="text-sienna shrink-0" />
+            <span className={formData.date ? 'text-text text-sm' : 'text-muted-text text-sm'}>
+              {formatDate(formData.date) || 'Select a date'}
+            </span>
+          </PopoverTrigger>
+          <PopoverContent align="start" className="w-auto p-0">
+            <Calendar
+              mode="single"
+              selected={formData.date}
+              onSelect={(date) => {
+                updateFormData({ date })
+                setCalendarOpen(false)
+              }}
+            />
+          </PopoverContent>
+        </Popover>
+        {errors.date && <p className="text-destructive text-xs mt-1.5">{errors.date}</p>}
+      </div>
+
+      <div>
+        <label className="text-[11px] uppercase tracking-[0.15em] text-muted-text mb-2 block">
+          <MapPin size={11} className="inline mr-1.5 relative -top-px" />
+          Place
+        </label>
+        {showLocationSearch ? (
+          <div
+            className={`w-full rounded-lg border transition-colors ${
+              errors.location ? 'border-destructive' : 'border-accent-warm bg-surface'
+            }`}
+          >
+            <div className="flex items-center gap-3 px-3.5 w-full min-w-0">
+              <MapPin size={16} className="text-sienna shrink-0" />
+              <div className="flex-1 min-w-0 [&_*]:!border-0 [&_*]:!shadow-none [&_.css-13cymwt-control]:!bg-transparent [&_.css-t3ipsp-control]:!bg-transparent">
+                <LocationSearchBox
+                  onSelectLocation={handleLocationChange}
+                  currentLocation={formData.location}
+                  editMode={true}
+                />
+              </div>
+            </div>
+          </div>
+        ) : (
+          <button
+            onClick={() => setShowLocationSearch(true)}
+            className={`w-full flex items-center gap-3 p-3.5 rounded-lg border bg-surface text-left transition-colors min-w-0 ${
+              errors.location ? 'border-destructive' : 'border-accent-warm hover:border-sienna/50'
+            }`}
+          >
+            <MapPin size={16} className="text-sienna shrink-0" />
+            <span className={`flex-1 min-w-0 truncate ${formData.location ? 'text-text text-sm' : 'text-muted-text text-sm'}`}>
+              {formData.location || 'Search a place…'}
+            </span>
+          </button>
+        )}
+        {errors.location && <p className="text-destructive text-xs mt-1.5">{errors.location}</p>}
+        {recentPlaces?.length > 0 && (
+          <div className="mt-3">
+            <p className="text-[10px] uppercase tracking-[0.15em] text-muted-text mb-2">Recent</p>
+            <div className="flex flex-wrap gap-2">
+              {recentPlaces.map((place) => (
+                <button
+                  key={place}
+                  onClick={() => updateFormData({ location: place })}
+                  className={`px-3 py-1.5 rounded-md text-xs transition-colors max-w-full truncate ${
+                    formData.location === place
+                      ? 'bg-foreground text-background'
+                      : 'bg-surface border border-accent-warm text-text hover:border-sienna'
+                  }`}
+                  title={place}
+                >
+                  <Clock size={10} className="inline mr-1 relative -top-px opacity-60" />
+                  {place}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/Pages/EditEvent/index.jsx
+++ b/src/Pages/EditEvent/index.jsx
@@ -1,0 +1,296 @@
+import { useEffect, useState } from 'react'
+import { useNavigate, useParams, useLocation } from 'react-router-dom'
+import { Timestamp } from 'firebase/firestore'
+import { ArrowLeft } from 'lucide-react'
+import { useToast } from '@chakra-ui/react'
+import { getEvent, getEvents, updateEvent, deleteEvent } from '../../db'
+import { toJsDate } from '../../utils'
+import { StepBasics } from './StepBasics'
+import { StepWhenWhere } from './StepWhenWhere'
+import { StepDetails } from './StepDetails'
+import { StepReview } from './StepReview'
+import { Saved } from './Saved'
+
+const STEPS = ['Basics', 'When & where', 'Details', 'Review']
+const STEP_EYEBROWS = ['Step 1 · Basics', 'Step 2 · When & where', 'Step 3 · Details', 'Step 4 · Review']
+const STEP_TITLES = [
+  'What are you planning?',
+  'A place & a time.',
+  'A little more to remember it by.',
+  'Look right?',
+]
+const STEP_NEXT_LABELS = ['Next', 'Next', 'Review', 'Save changes']
+
+const DEFAULT_CATEGORIES = ['Meals', 'Gifts', 'Trips']
+
+function eventToForm(event) {
+  return {
+    title: event.title || '',
+    description: event.description || '',
+    date: toJsDate(event.date),
+    location: event.location || '',
+    categories: event.categories?.length
+      ? [...event.categories]
+      : (event.category ? [event.category] : []),
+    people: event.people ? [...event.people] : [],
+    photos: event.photos?.length ? [...event.photos] : (event.thumbnail ? [event.thumbnail] : []),
+  }
+}
+
+export default function EditEvent() {
+  const { id } = useParams()
+  const navigate = useNavigate()
+  const locationHook = useLocation()
+  const toast = useToast()
+
+  const [formData, setFormData] = useState(
+    locationHook.state?.event ? eventToForm(locationHook.state.event) : null
+  )
+  const [loading, setLoading] = useState(!formData)
+  const [errors, setErrors] = useState({})
+  const [currentStep, setCurrentStep] = useState(0)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [savedEvent, setSavedEvent] = useState(null)
+  const [recentPlaces, setRecentPlaces] = useState([])
+
+  useEffect(() => {
+    if (formData) return
+    let cancelled = false
+    setLoading(true)
+    getEvent(id)
+      .then((data) => {
+        if (cancelled || !data) return
+        setFormData(eventToForm(data))
+      })
+      .finally(() => !cancelled && setLoading(false))
+    return () => { cancelled = true }
+  }, [id])
+
+  useEffect(() => {
+    getEvents()
+      .then((events) => {
+        const seen = new Set()
+        const places = []
+        events
+          .sort((a, b) => (b.date?.seconds || 0) - (a.date?.seconds || 0))
+          .forEach((e) => {
+            if (e.id === id) return
+            const loc = e.location
+            if (loc && !seen.has(loc)) {
+              seen.add(loc)
+              places.push(loc)
+            }
+          })
+        setRecentPlaces(places.slice(0, 5))
+      })
+      .catch(() => setRecentPlaces([]))
+  }, [id])
+
+  const updateFormData = (updates) => {
+    setFormData((prev) => ({ ...prev, ...updates }))
+    setErrors((prev) => {
+      const next = { ...prev }
+      Object.keys(updates).forEach((k) => delete next[k])
+      return next
+    })
+  }
+
+  const validateStep = (step) => {
+    const next = {}
+    if (step === 0 && !formData.title.trim()) next.title = 'Title is required'
+    if (step === 1) {
+      if (!formData.date) next.date = 'Date is required'
+      if (!formData.location) next.location = 'Place is required'
+    }
+    setErrors(next)
+    return Object.keys(next).length === 0
+  }
+
+  const handleNext = () => {
+    if (!validateStep(currentStep)) return
+    if (currentStep < STEPS.length - 1) {
+      setCurrentStep((s) => s + 1)
+    } else {
+      handleSave()
+    }
+  }
+
+  const handleBack = () => setCurrentStep((s) => Math.max(0, s - 1))
+
+  const handleSave = async () => {
+    setIsSubmitting(true)
+    try {
+      const payload = {
+        id,
+        title: formData.title.trim(),
+        description: formData.description.trim(),
+        date: Timestamp.fromDate(formData.date),
+        location: formData.location,
+        categories: formData.categories,
+        people: formData.people,
+        photos: formData.photos,
+      }
+      await updateEvent(payload)
+      setSavedEvent(payload)
+    } catch (err) {
+      console.error('Save failed', err)
+      toast({
+        title: 'Save failed',
+        description: err.message || 'Please try again.',
+        status: 'error',
+        duration: 4000,
+        isClosable: true,
+      })
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const handleDelete = async () => {
+    setIsSubmitting(true)
+    try {
+      await deleteEvent(id)
+      toast({ title: 'Event deleted', status: 'success', duration: 2500, isClosable: true })
+      navigate('/events')
+    } catch (err) {
+      console.error('Delete failed', err)
+      toast({
+        title: 'Delete failed',
+        description: err.message || 'Please try again.',
+        status: 'error',
+        duration: 4000,
+        isClosable: true,
+      })
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const jumpToStep = (step) => setCurrentStep(step)
+
+  if (loading || !formData) {
+    return (
+      <div className="min-h-[calc(100vh-80px)] bg-parchment flex items-center justify-center">
+        <p className="text-muted-text text-sm">Loading…</p>
+      </div>
+    )
+  }
+
+  if (savedEvent) {
+    return (
+      <Saved
+        event={savedEvent}
+        onEditAgain={() => {
+          setSavedEvent(null)
+          setCurrentStep(0)
+        }}
+      />
+    )
+  }
+
+  return (
+    <div className="min-h-[calc(100vh-80px)] bg-parchment flex flex-col">
+      <div className="flex items-center justify-between px-5 pt-4 pb-2">
+        <button
+          onClick={() => navigate(-1)}
+          aria-label="Back"
+          className="w-9 h-9 rounded-full bg-surface shadow-soft flex items-center justify-center text-text hover:bg-accent-warm/40 transition-colors"
+        >
+          <ArrowLeft size={18} />
+        </button>
+        <span className="font-display text-[18px] text-text">Edit event</span>
+        <span className="w-9 h-9" aria-hidden />
+      </div>
+
+      <div className="px-5 max-w-lg w-full mx-auto pt-4">
+        <div className="flex items-center gap-1.5 mb-2">
+          {STEPS.map((_, idx) => (
+            <div
+              key={idx}
+              className={`h-[3px] flex-1 rounded-full transition-colors ${
+                idx < currentStep
+                  ? 'bg-foreground'
+                  : idx === currentStep
+                  ? 'bg-sienna'
+                  : 'bg-accent-warm'
+              }`}
+            />
+          ))}
+        </div>
+        <div className="flex items-center justify-between text-[11px] uppercase tracking-[0.15em] text-muted-text">
+          <span>{STEP_EYEBROWS[currentStep]}</span>
+          <span>{currentStep + 1} of {STEPS.length}</span>
+        </div>
+        <h1 className="font-display text-[28px] leading-[1.15] text-text mt-3 mb-6">
+          {STEP_TITLES[currentStep]}
+        </h1>
+      </div>
+
+      <div className="flex-1 px-5 pb-28 max-w-lg w-full mx-auto">
+        {currentStep === 0 && (
+          <StepBasics
+            formData={formData}
+            updateFormData={updateFormData}
+            errors={errors}
+            defaultCategories={DEFAULT_CATEGORIES}
+          />
+        )}
+        {currentStep === 1 && (
+          <StepWhenWhere
+            formData={formData}
+            updateFormData={updateFormData}
+            errors={errors}
+            recentPlaces={recentPlaces}
+          />
+        )}
+        {currentStep === 2 && (
+          <StepDetails
+            formData={formData}
+            updateFormData={updateFormData}
+            errors={errors}
+          />
+        )}
+        {currentStep === 3 && (
+          <StepReview
+            formData={formData}
+            onEditStep={jumpToStep}
+            onDelete={handleDelete}
+            isSubmitting={isSubmitting}
+          />
+        )}
+      </div>
+
+      <div className="fixed bottom-0 left-0 right-0 bg-parchment border-t border-accent-warm/30 px-5 py-4">
+        <div className="max-w-lg mx-auto flex items-center gap-3">
+          {currentStep > 0 ? (
+            <button
+              onClick={handleBack}
+              className="px-5 py-3 rounded border border-accent-warm text-text text-xs uppercase tracking-[0.15em] hover:bg-accent-warm/30 transition-colors"
+            >
+              ← Back
+            </button>
+          ) : (
+            <button
+              onClick={() => navigate(`/events/${id}`)}
+              className="px-5 py-3 rounded border border-accent-warm text-muted-text text-xs uppercase tracking-[0.15em] hover:bg-accent-warm/30 transition-colors"
+            >
+              Cancel
+            </button>
+          )}
+          <button
+            onClick={handleNext}
+            disabled={isSubmitting}
+            className={`flex-1 py-3.5 rounded font-medium text-xs uppercase tracking-[0.15em] transition-opacity disabled:opacity-50 disabled:cursor-not-allowed ${
+              currentStep === STEPS.length - 1
+                ? 'bg-foreground text-background hover:opacity-90'
+                : 'bg-sienna text-white hover:opacity-90'
+            }`}
+          >
+            {isSubmitting ? 'Saving…' : STEP_NEXT_LABELS[currentStep] + (currentStep < STEPS.length - 1 ? ' →' : '')}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+

--- a/src/Pages/EventDetail/index.jsx
+++ b/src/Pages/EventDetail/index.jsx
@@ -1,0 +1,221 @@
+import { useEffect, useState } from 'react'
+import { useNavigate, useParams, useLocation } from 'react-router-dom'
+import { ArrowLeft, MapPin, Users, FileText, Pencil, Trash2 } from 'lucide-react'
+import { useToast } from '@chakra-ui/react'
+import { getEvent, deleteEvent } from '../../db'
+import { toJsDate } from '../../utils'
+
+function formatLongDate(ts) {
+  const d = toJsDate(ts)
+  if (!d) return ''
+  const weekday = d.toLocaleDateString('en-US', { weekday: 'short' }).toUpperCase()
+  const month = d.toLocaleDateString('en-US', { month: 'short' }).toUpperCase()
+  return `${weekday} · ${month} ${d.getDate()}, ${d.getFullYear()}`
+}
+
+export default function EventDetail() {
+  const { id } = useParams()
+  const navigate = useNavigate()
+  const location = useLocation()
+  const toast = useToast()
+  const [event, setEvent] = useState(location.state?.event || null)
+  const [loading, setLoading] = useState(!event)
+  const [error, setError] = useState(null)
+  const [confirmDelete, setConfirmDelete] = useState(false)
+  const [deleting, setDeleting] = useState(false)
+
+  const handleDelete = async () => {
+    setDeleting(true)
+    try {
+      await deleteEvent(id)
+      toast({ title: 'Event deleted', status: 'success', duration: 2500, isClosable: true })
+      navigate('/events')
+    } catch (err) {
+      setDeleting(false)
+      setConfirmDelete(false)
+      toast({
+        title: 'Delete failed',
+        description: err.message || 'Please try again.',
+        status: 'error',
+        duration: 4000,
+        isClosable: true,
+      })
+    }
+  }
+
+  useEffect(() => {
+    if (event && event.id === id) return
+    let cancelled = false
+    setLoading(true)
+    getEvent(id)
+      .then((data) => {
+        if (cancelled) return
+        if (!data) setError('Event not found')
+        else setEvent(data)
+      })
+      .catch((e) => !cancelled && setError(e.message || 'Failed to load'))
+      .finally(() => !cancelled && setLoading(false))
+    return () => { cancelled = true }
+  }, [id])
+
+  if (loading) {
+    return (
+      <div className="min-h-[calc(100vh-80px)] bg-parchment flex items-center justify-center">
+        <p className="text-muted-text text-sm">Loading…</p>
+      </div>
+    )
+  }
+
+  if (error || !event) {
+    return (
+      <div className="min-h-[calc(100vh-80px)] bg-parchment flex items-center justify-center px-6">
+        <div className="text-center">
+          <p className="text-text">{error || 'Event not found'}</p>
+          <button
+            onClick={() => navigate('/events')}
+            className="mt-4 px-4 py-2 bg-foreground text-background rounded text-sm uppercase tracking-wider"
+          >
+            Back to events
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  const categories = event.categories?.length ? event.categories : (event.category ? [event.category] : [])
+  const people = event.people || []
+  const photos = event.photos?.length ? event.photos : (event.thumbnail ? [event.thumbnail] : [])
+
+  return (
+    <div className="min-h-[calc(100vh-80px)] bg-parchment flex flex-col">
+      <div className="flex items-center justify-between px-5 pt-4 pb-2">
+        <button
+          onClick={() => navigate(-1)}
+          aria-label="Back"
+          className="w-9 h-9 rounded-full bg-surface shadow-soft flex items-center justify-center text-text hover:bg-accent-warm/40 transition-colors"
+        >
+          <ArrowLeft size={18} />
+        </button>
+        <span className="text-[12px] font-medium tracking-[0.2em] text-muted-text uppercase">Event</span>
+        <button
+          onClick={() => setConfirmDelete(true)}
+          aria-label="Delete event"
+          className="w-9 h-9 rounded-full bg-surface shadow-soft flex items-center justify-center text-text hover:bg-destructive/10 hover:text-destructive transition-colors"
+        >
+          <Trash2 size={16} />
+        </button>
+      </div>
+
+      {confirmDelete && (
+        <div
+          className="fixed inset-0 z-50 bg-black/40 flex items-end sm:items-center justify-center px-4 pb-4 sm:pb-0"
+          onClick={() => !deleting && setConfirmDelete(false)}
+        >
+          <div
+            className="bg-surface rounded-lg shadow-soft max-w-sm w-full p-5"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h2 className="font-display text-[20px] text-text mb-2">Delete this event?</h2>
+            <p className="text-text/70 text-sm leading-relaxed mb-5">
+              This event will be removed permanently. This cannot be undone.
+            </p>
+            <div className="flex gap-2">
+              <button
+                onClick={() => setConfirmDelete(false)}
+                disabled={deleting}
+                className="flex-1 py-2.5 rounded border border-accent-warm text-text text-xs uppercase tracking-[0.15em] hover:bg-accent-warm/30 transition-colors disabled:opacity-50"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleDelete}
+                disabled={deleting}
+                className="flex-1 py-2.5 rounded bg-destructive text-white text-xs uppercase tracking-[0.15em] hover:opacity-90 transition-opacity disabled:opacity-50"
+              >
+                {deleting ? 'Deleting…' : 'Delete'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <div className="flex-1 px-5 pb-28 pt-4 max-w-lg w-full mx-auto">
+        {photos.length > 0 && (
+          <div className="mb-6 rounded-sm overflow-hidden shadow-soft">
+            <img
+              src={photos[0]}
+              alt={event.title}
+              className="w-full h-[260px] object-cover"
+            />
+          </div>
+        )}
+
+        {categories.length > 0 && (
+          <div className="flex flex-wrap gap-2 mb-5">
+            {categories.map((cat) => (
+              <span
+                key={cat}
+                className="inline-flex items-center px-3 py-1 bg-accent-warm/60 text-text text-[11px] font-medium tracking-wider uppercase rounded-sm"
+              >
+                {cat}
+              </span>
+            ))}
+          </div>
+        )}
+
+        <h1 className="font-display text-[32px] font-medium leading-[1.1] text-text">
+          {event.title}
+        </h1>
+        <p className="mt-3 text-[12px] font-medium tracking-[0.15em] text-muted-text uppercase">
+          {formatLongDate(event.date)}
+        </p>
+
+        <hr className="border-accent-warm/50 my-6" />
+
+        {event.location && (
+          <Row icon={<MapPin size={14} className="text-sienna" />} label="Place">
+            <p className="text-text">{event.location}</p>
+          </Row>
+        )}
+
+        {people.length > 0 && (
+          <Row icon={<Users size={14} className="text-sienna" />} label="Who's coming">
+            <p className="text-text">{people.join(' & ')}</p>
+          </Row>
+        )}
+
+        {event.description && (
+          <Row icon={<FileText size={14} className="text-sienna" />} label="Notes">
+            <p className="text-text/80 italic leading-relaxed">{event.description}</p>
+          </Row>
+        )}
+      </div>
+
+      <div className="fixed bottom-0 left-0 right-0 bg-parchment border-t border-accent-warm/30 px-5 py-4">
+        <div className="max-w-lg mx-auto">
+          <button
+            onClick={() => navigate(`/events/${id}/edit`, { state: { event } })}
+            className="w-full bg-foreground text-background py-3.5 rounded font-medium text-sm uppercase tracking-[0.15em] hover:opacity-90 transition-opacity flex items-center justify-center gap-2"
+          >
+            <Pencil size={14} />
+            Edit Event
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function Row({ icon, label, children }) {
+  return (
+    <div className="flex items-start gap-3 py-4 border-b border-accent-warm/40 last:border-b-0">
+      <div className="w-8 h-8 rounded-full bg-accent-warm/40 flex items-center justify-center shrink-0">
+        {icon}
+      </div>
+      <div className="flex-1 min-w-0">
+        <p className="text-[11px] font-medium tracking-[0.15em] text-muted-text uppercase mb-1">{label}</p>
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/src/Pages/EventsList/Components/EventCard.jsx
+++ b/src/Pages/EventsList/Components/EventCard.jsx
@@ -1,20 +1,37 @@
-import { useState } from 'react'
+import { useState, useRef } from 'react'
 import { convertFbTimestampToDate } from '../../../utils'
 import { MapPin, ChevronLeft, ChevronRight } from 'lucide-react';
 
 export const EventCard = ({ event, onOpen }) => {
     const dateStr = convertFbTimestampToDate(event.date);
     const photos = event.photos?.length ? event.photos : (event.thumbnail ? [event.thumbnail] : []);
+    const categories = event.categories?.length ? event.categories : (event.category ? [event.category] : []);
+    const trackRef = useRef(null);
     const [currentIndex, setCurrentIndex] = useState(0);
+
+    const scrollToIndex = (idx) => {
+        const track = trackRef.current;
+        if (!track) return;
+        track.scrollTo({ left: idx * track.clientWidth, behavior: 'smooth' });
+    };
 
     const handlePrev = (e) => {
         e.stopPropagation();
-        setCurrentIndex((prev) => (prev - 1 + photos.length) % photos.length);
+        e.preventDefault();
+        scrollToIndex((currentIndex - 1 + photos.length) % photos.length);
     };
 
     const handleNext = (e) => {
         e.stopPropagation();
-        setCurrentIndex((prev) => (prev + 1) % photos.length);
+        e.preventDefault();
+        scrollToIndex((currentIndex + 1) % photos.length);
+    };
+
+    const handleScroll = () => {
+        const track = trackRef.current;
+        if (!track) return;
+        const idx = Math.round(track.scrollLeft / track.clientWidth);
+        if (idx !== currentIndex) setCurrentIndex(idx);
     };
 
     return (
@@ -25,11 +42,21 @@ export const EventCard = ({ event, onOpen }) => {
             {/* Image carousel */}
             <div className="relative w-full h-[280px] overflow-hidden">
                 {photos.length > 0 ? (
-                    <img
-                        src={photos[currentIndex]}
-                        alt={`Photo ${currentIndex + 1} for ${event.title}`}
-                        className="w-full !h-full object-cover transform group-hover:scale-[1.02] transition-transform duration-500 ease-out"
-                    />
+                    <div
+                        ref={trackRef}
+                        onScroll={handleScroll}
+                        className="flex w-full h-full overflow-x-auto snap-x snap-mandatory scroll-smooth [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden"
+                    >
+                        {photos.map((src, idx) => (
+                            <img
+                                key={idx}
+                                src={src}
+                                alt={`Photo ${idx + 1} for ${event.title}`}
+                                draggable={false}
+                                className="w-full h-full flex-shrink-0 snap-center object-cover transform group-hover:scale-[1.02] transition-transform duration-500 ease-out"
+                            />
+                        ))}
+                    </div>
                 ) : (
                     <img
                         src="https://via.placeholder.com/600x400"
@@ -40,14 +67,18 @@ export const EventCard = ({ event, onOpen }) => {
                 {photos.length > 1 && (
                     <>
                         <button
+                            type="button"
+                            aria-label="Previous photo"
                             onClick={handlePrev}
-                            className="absolute left-2 top-1/2 -translate-y-1/2 bg-black/40 hover:bg-black/60 text-white rounded-full p-1 opacity-0 group-hover:opacity-100 transition-opacity"
+                            className="absolute left-2 top-1/2 -translate-y-1/2 bg-black/50 hover:bg-black/70 text-white rounded-full p-1.5 transition-colors z-10"
                         >
                             <ChevronLeft size={18} />
                         </button>
                         <button
+                            type="button"
+                            aria-label="Next photo"
                             onClick={handleNext}
-                            className="absolute right-2 top-1/2 -translate-y-1/2 bg-black/40 hover:bg-black/60 text-white rounded-full p-1 opacity-0 group-hover:opacity-100 transition-opacity"
+                            className="absolute right-2 top-1/2 -translate-y-1/2 bg-black/50 hover:bg-black/70 text-white rounded-full p-1.5 transition-colors z-10"
                         >
                             <ChevronRight size={18} />
                         </button>
@@ -96,11 +127,13 @@ export const EventCard = ({ event, onOpen }) => {
                 </div>
 
                 {/* Category tag */}
-                {event.category && (
-                    <div className="flex gap-2">
-                        <span className="px-3 py-1 bg-parchment text-muted-text text-xs rounded-sm">
-                            #{event.category}
-                        </span>
+                {categories.length > 0 && (
+                    <div className="flex flex-wrap gap-2">
+                        {categories.map((cat) => (
+                            <span key={cat} className="px-3 py-1 bg-parchment text-muted-text text-xs rounded-sm">
+                                #{cat}
+                            </span>
+                        ))}
                     </div>
                 )}
             </div>

--- a/src/Pages/EventsList/Components/EventModal.jsx
+++ b/src/Pages/EventsList/Components/EventModal.jsx
@@ -48,6 +48,12 @@ export const EventModal = ({ handleDeleteEvent, handleUpdateEvent, event, isOpen
         return availableCategories.filter(category => category.label !== "All")
     }, [availableCategories])
 
+    const displayCategories = useMemo(() => {
+        if (event.categories?.length) return event.categories
+        if (event.category) return [event.category]
+        return []
+    }, [event.categories, event.category])
+
     const handleEdit = () => {
         setEditedEvent(event)
         setEditMode(true);
@@ -133,7 +139,15 @@ export const EventModal = ({ handleDeleteEvent, handleUpdateEvent, event, isOpen
                                     </MenuList>
                                 </Menu>
                             ) : (
-                                <Badge p="2" borderRadius="6px" colorScheme='green'>{event.category || "Unknown Category"}</Badge>
+                                <Box display="flex" flexWrap="wrap" gap="6px">
+                                    {displayCategories.length ? (
+                                        displayCategories.map((cat) => (
+                                            <Badge key={cat} p="2" borderRadius="6px" colorScheme='green'>{cat}</Badge>
+                                        ))
+                                    ) : (
+                                        <Badge p="2" borderRadius="6px" colorScheme='gray'>Uncategorized</Badge>
+                                    )}
+                                </Box>
                             )}
 
                             { editMode ? (

--- a/src/Pages/EventsList/Components/LocationSearchBox.jsx
+++ b/src/Pages/EventsList/Components/LocationSearchBox.jsx
@@ -67,7 +67,7 @@ export const LocationSearchBox = ({ onSelectLocation, currentLocation, editMode 
     };
 
     return (
-        <Box>
+        <Box width="100%" minW={0}>
             <AsyncSelect
                 cacheOptions
                 loadOptions={loadOptions}
@@ -75,6 +75,8 @@ export const LocationSearchBox = ({ onSelectLocation, currentLocation, editMode 
                 onChange={handleOnSelectLocation}
                 placeholder="Search for locations..."
                 defaultInputValue={displayInput}
+                menuPortalTarget={typeof document !== 'undefined' ? document.body : null}
+                menuPosition="fixed"
                 components={{
                     DropdownIndicator: editMode
                         ? null // Do not render the dropdown indicator in edit mode
@@ -85,18 +87,22 @@ export const LocationSearchBox = ({ onSelectLocation, currentLocation, editMode 
                         ),
                 }}
                 styles={{
+                    container: (provided) => ({ ...provided, width: '100%', minWidth: 0 }),
                     control: (provided) => ({
                         ...provided,
+                        width: '100%',
                         padding: '4px',
                         boxShadow: 'none',
                         borderColor: 'lightgray',
-                        ':hover': {
-                            borderColor: 'gray',
-                        },
+                        ':hover': { borderColor: 'gray' },
                     }),
-                    indicatorSeparator: () => ({
-                        display: 'none',
-                    }),
+                    valueContainer: (provided) => ({ ...provided, flexWrap: 'nowrap', overflow: 'hidden', minWidth: 0 }),
+                    singleValue: (provided) => ({ ...provided, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: '100%' }),
+                    input: (provided) => ({ ...provided, minWidth: 0 }),
+                    menuPortal: (provided) => ({ ...provided, zIndex: 60 }),
+                    menu: (provided) => ({ ...provided, zIndex: 60 }),
+                    option: (provided) => ({ ...provided, whiteSpace: 'normal', wordBreak: 'break-word' }),
+                    indicatorSeparator: () => ({ display: 'none' }),
                 }}
             />
         </Box>

--- a/src/Pages/EventsList/index.jsx
+++ b/src/Pages/EventsList/index.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, useCallback, useMemo } from "react"
+import { useNavigate } from "react-router-dom";
 import {
     Box,
     Spinner,
@@ -14,9 +15,8 @@ import { AddEventModal } from "./Components/AddEventModal";
 import { SearchFilter } from "./Components/SearchFilter"
 import { FilterPanel } from "./Components/FilterPanel"
 import { EventCard } from "./Components/EventCard";
-import { EventModal } from "./Components/EventModal";
 import { EmptySearchState } from "./Components/EmptyState";
-import { getEvents, uploadEvent, deleteEvent, updateEvent } from "../../db";
+import { getEvents, uploadEvent } from "../../db";
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
@@ -27,6 +27,7 @@ import {
 
 
 const EventPage = () => {
+    const navigate = useNavigate();
     const defaultEventData = {
         title: '',
         description: '',
@@ -72,9 +73,7 @@ const EventPage = () => {
     const [currentPage, setCurrentPage] = useState(1);
     const itemsPerPage = 6;
 
-    const { isOpen, onOpen, onClose } = useDisclosure();
     const { isOpen: isAddModalOpen, onOpen: onAddModalOpen, onClose: onAddModalClose } = useDisclosure();
-    const [selectedEvent, setSelectedEvent] = useState(null);
     const [isDateFilterOpen, dateFilterParam, openDateFilter, closeDateFilter, updateDateFilterParam] = useModalParams();
 
     const fetchEvents = async () => {
@@ -111,11 +110,10 @@ const EventPage = () => {
 
         if (selectedCategories.length) {
             filteredResults = filteredResults.filter(event => {
-                if (!selectedCategories.length) {
-                    return true
-                } else {
-                    return selectedCategories.includes(event.category)
-                }
+                const eventCats = event.categories?.length
+                    ? event.categories
+                    : (event.category ? [event.category] : [])
+                return eventCats.some(c => selectedCategories.includes(c))
             })
         }
 
@@ -176,20 +174,6 @@ const EventPage = () => {
         onAddModalClose();
     };
 
-    const handleDeleteEvent = async (event) => {
-        setIsLoading(true)
-
-        try {
-            await deleteEvent(event.id)
-            await fetchEvents()
-        } catch (err) {
-            console.log(err, 'delete event failed')
-        } finally {
-            setIsLoading(false)
-            onClose();
-        }
-    };
-
     const onSelectCategory = (categories) => {
         setSelectedCategories(categories)
     }
@@ -199,22 +183,8 @@ const EventPage = () => {
     }
 
     const handleCardClick = (event) => {
-        setSelectedEvent(event);
-        onOpen();
+        navigate(`/events/${event.id}`, { state: { event } });
     };
-
-    const handleUpdateEvent = async (event) => {
-        setIsLoading(true)
-
-        try {
-            await updateEvent(event)
-            await fetchEvents()
-        } catch (err) {
-            console.log(err, 'error updating event')
-        } finally {
-            handleCardClick(event)
-        }
-    }
 
     const handlePageChange = (newPage) => {
         setCurrentPage(newPage);
@@ -300,16 +270,6 @@ const EventPage = () => {
                                 </ButtonGroup>
                             </Box>
                         ) : <EmptySearchState />}
-                        {selectedEvent && (
-                            <EventModal
-                                handleDeleteEvent={handleDeleteEvent}
-                                handleUpdateEvent={handleUpdateEvent}
-                                event={selectedEvent}
-                                isOpen={isOpen}
-                                onClose={onClose}
-                                availableCategories={menuLists}
-                            />
-                        )}
                         <AddEventModal
                             menuLists={menuLists}
                             newEvent={newEvent}

--- a/src/db/index.js
+++ b/src/db/index.js
@@ -11,6 +11,13 @@ export const getEvents = async () => {
     return eventList;
 }
 
+export const getEvent = async (id) => {
+    const eventDocRef = doc(db, "events", id);
+    const snap = await getDoc(eventDocRef);
+    if (!snap.exists()) return null;
+    return { id: snap.id, ...snap.data() };
+}
+
 export const uploadEvent = async (newEvent) => {
     const eventsCol = collection(db, "events");
     const { file, files, ...eventData } = newEvent

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,19 +1,30 @@
 import { Timestamp } from "firebase/firestore";
 import { multiUpdate, getValue } from "../db/rtdb";
 
-export const convertFbTimestampToDate = (firestoreTimestamp) => {
-    if (!firestoreTimestamp) return 'This event does not have a date';
-
-    // Convert Firestore Timestamp to JavaScript Date object
-    let date
-    if (typeof firestoreTimestamp === 'number') {
-        date = new Date(firestoreTimestamp);
-    } else {
-        date = firestoreTimestamp?.toDate()
+// Tolerant Timestamp → Date.
+// Router state serialization strips the Firestore `Timestamp` prototype,
+// leaving a plain `{seconds, nanoseconds}` shape. Handle every variant.
+export const toJsDate = (value) => {
+    if (!value) return null;
+    if (value instanceof Date) return value;
+    if (typeof value === 'number') return new Date(value);
+    if (typeof value === 'string') {
+        const d = new Date(value);
+        return isNaN(d.getTime()) ? null : d;
     }
+    if (typeof value.toDate === 'function') return value.toDate();
+    if (typeof value.seconds === 'number') {
+        return new Date(value.seconds * 1000 + (value.nanoseconds || 0) / 1e6);
+    }
+    return null;
+}
+
+export const convertFbTimestampToDate = (firestoreTimestamp) => {
+    const date = toJsDate(firestoreTimestamp);
+    if (!date) return 'This event does not have a date';
 
     const day = date.getDate();
-    const month = date.getMonth() + 1; // Months are zero-based
+    const month = date.getMonth() + 1;
     const year = date.getFullYear();
 
     return `${day}/${month}/${year}`;


### PR DESCRIPTION
Replaces the inline-edit modal with a full-page event detail screen (/events/:id) and a 4-step edit wizard (/events/:id/edit) covering basics, when & where, details, and review. Tapping the trash icon on detail surfaces a confirmation modal; the review step also surfaces a danger zone delete. Saved screen shows the new event recap and routes both back actions to the events list.

Also fixes a few card-level issues uncovered along the way:
- swipeable image carousel via CSS scroll-snap with always-visible chevrons
- categories display on the card and in filtering (legacy `category` → new `categories[]`)
- tolerant Firestore Timestamp parsing so router-state-stripped prototypes still render real dates
- LocationSearchBox no longer overflows on narrow viewports