### PR TITLE
Fix edit back button and add text context to AI caption

### DIFF
--- a/src/Pages/AddEvent/StepStory.jsx
+++ b/src/Pages/AddEvent/StepStory.jsx
@@ -11,7 +11,10 @@ export function StepStory({ formData, updateFormData, errors }) {
     setIsGenerating(true)
     setGenerateError(null)
     try {
-      const result = await generateCaption(formData.files)
+      const result = await generateCaption(formData.files, {
+        title: formData.title,
+        description: formData.description,
+      })
       updateFormData({
         title: result.title || formData.title,
         description: result.description || formData.description,

--- a/src/Pages/EditEvent/index.jsx
+++ b/src/Pages/EditEvent/index.jsx
@@ -192,7 +192,7 @@ export default function EditEvent() {
     <div className="min-h-[calc(100vh-80px)] bg-parchment flex flex-col">
       <div className="flex items-center justify-between px-5 pt-4 pb-2">
         <button
-          onClick={() => navigate(-1)}
+          onClick={() => navigate('/events')}
           aria-label="Back"
           className="w-9 h-9 rounded-full bg-surface shadow-soft flex items-center justify-center text-text hover:bg-accent-warm/40 transition-colors"
         >

--- a/src/utils/generateCaption.js
+++ b/src/utils/generateCaption.js
@@ -25,7 +25,15 @@ Guidelines:
 - If you can identify the activity, location type, or mood, mention it naturally
 - Keep the tone lighthearted and loving`
 
-async function callModel(model, imageContent) {
+function buildUserHints({ title, description } = {}) {
+  const hints = []
+  if (title?.trim()) hints.push(`Title the user already wrote: "${title.trim()}"`)
+  if (description?.trim()) hints.push(`Description/notes the user already wrote: "${description.trim()}"`)
+  if (!hints.length) return ''
+  return `\n\nThe user has provided the following context about the photos — use it to ground your title and description so they match what actually happened:\n${hints.join('\n')}`
+}
+
+async function callModel(model, imageContent, hints) {
   const response = await fetch('https://openrouter.ai/api/v1/chat/completions', {
     method: 'POST',
     headers: {
@@ -37,7 +45,7 @@ async function callModel(model, imageContent) {
       messages: [
         {
           role: 'user',
-          content: [...imageContent, { type: 'text', text: PROMPT }],
+          content: [...imageContent, { type: 'text', text: PROMPT + hints }],
         },
       ],
     }),
@@ -51,7 +59,7 @@ async function callModel(model, imageContent) {
   return response.json()
 }
 
-export async function generateCaption(files) {
+export async function generateCaption(files, context = {}) {
   const imageFiles = files.slice(0, 4)
   const base64Images = await Promise.all(imageFiles.map(fileToBase64))
 
@@ -60,10 +68,12 @@ export async function generateCaption(files) {
     image_url: { url: dataUrl },
   }))
 
+  const hints = buildUserHints(context)
+
   let lastError
   for (const model of MODELS) {
     try {
-      const data = await callModel(model, imageContent)
+      const data = await callModel(model, imageContent, hints)
       const content = data.choices?.[0]?.message?.content?.trim()
 
       try {


### PR DESCRIPTION
## Summary
- The edit-event back button now always navigates to the event list (`/events`) instead of the last visited page.
- "Generate with AI" now sends the user's title and description along with the photos, so generated captions are grounded in the user's own context rather than the image alone.

## Changes
- `src/Pages/EditEvent/index.jsx` — back button uses `navigate('/events')` instead of `navigate(-1)`.
- `src/utils/generateCaption.js` — `generateCaption(files, context)` appends user-written title/description as prompt hints (omitted when empty).
- `src/Pages/AddEvent/StepStory.jsx` — passes current title/description into `generateCaption`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)